### PR TITLE
fix: ensure CRT monitor displays loaded images

### DIFF
--- a/src/HeroScene.tsx
+++ b/src/HeroScene.tsx
@@ -304,6 +304,7 @@ const CRTComputer: React.FC<CRTComputerProps> = ({ position = [0, 0, 0] }) => {
           // Set up onload to trigger redraw when image loads
           img.onload = () => {
             texture.needsUpdate = true
+            updateCanvas()
           }
         }
         


### PR DESCRIPTION
## Summary
- force CRT canvas to redraw when a slide image finishes loading

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: ESLint couldn't find a configuration file)

------
https://chatgpt.com/codex/tasks/task_e_6897d6b9657c8325b8e42044640da1c1