### PR TITLE
Revamp CRT scene to match reference

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,22 +1,19 @@
-import React, { Suspense, useState } from 'react'
+import React, { Suspense } from 'react'
 import { Canvas } from '@react-three/fiber'
 import { Loader } from '@react-three/drei'
-import HeroScene, { FolderId } from './HeroScene'
+import HeroScene from './HeroScene'
 
 const App: React.FC = () => {
-  const [openFolder, setOpenFolder] = useState<FolderId | null>(null)
-
   return (
-    <div className="relative min-h-screen bg-black">
+    <div className="relative min-h-screen bg-[#f4f0e6]">
       <Canvas
         className="w-full h-screen"
         shadows
-        dpr={[1, 1.5]}
-        camera={{ position: [0.12, 1.1, 2.15], fov: 32 }}
-        onPointerMissed={() => setOpenFolder(null)}
+        dpr={[1, 2]}
+        camera={{ position: [0.26, 0.62, 1.55], fov: 32 }}
       >
         <Suspense fallback={null}>
-          <HeroScene openFolder={openFolder} setOpenFolder={setOpenFolder} />
+          <HeroScene />
         </Suspense>
       </Canvas>
       <Loader


### PR DESCRIPTION
## Summary
- rebuild the hero scene with a beige CRT model, XP boot screen texture, and warm studio lighting to match the provided reference image
- tune the app shell styling, camera defaults, and orbit controls so viewers can easily center and zoom in on the computer

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cb4c5198f083258ffed038537d34c7